### PR TITLE
Add fıfa as a protected word

### DIFF
--- a/config/stemmer.yml
+++ b/config/stemmer.yml
@@ -59,6 +59,7 @@ protected_words:
   - elbise
   - fendi
   - filtre
+  - fıfa
   - fiyat
   - forma
   - gazete


### PR DESCRIPTION
This is needed so FIFA can have the same result (after ICU folding) as fifa.