### PR TITLE
Fix stemming for `kurutma` and `ledli`

### DIFF
--- a/benchmarks/stemming_samples.txt
+++ b/benchmarks/stemming_samples.txt
@@ -6147,10 +6147,10 @@ gazetelik,gazetelik
 gazetesi,gazete
 gazi,gazi
 gaziantep,gaziantep
-gazla,gazl
+gazla,gaz
 gazli,gazli
 gazlli,gazlli
-gazlı,gazl
+gazlı,gaz
 gazyagı,gazyag
 gazzaro,gazzaro
 gaıaksi,gaıaksi

--- a/benchmarks/stemming_samples.txt
+++ b/benchmarks/stemming_samples.txt
@@ -9001,7 +9001,7 @@ kurulması,kurulma
 kurulum,kurul
 kurulumu,kurul
 kurutceporno,kurutceporno
-kurutma,kurut
+kurutma,kurutma
 kurutmali,kurutmali
 kurutmalı,kurutma
 kurutucu,kurutuç
@@ -9300,8 +9300,8 @@ lecoste,lecoste
 lecoultre,lecoultre
 led,led
 lede,le
-ledler,let
-ledli,ledl
+ledler,led
+ledli,led
 ledsadece,ledsade
 ledtoplar,ledtop
 ledtv,ledtv

--- a/config/stemmer.yml
+++ b/config/stemmer.yml
@@ -158,11 +158,13 @@ protected_words:
   - yıldız
   - zayıflama
   - zemin
+  - kurutma
 
 last_consonant_exceptions:
   - ad
   - at
   - ked
+  - led
 
 vowel_harmony_exceptions:
   - alkoller
@@ -234,3 +236,4 @@ selection_list_exceptions:
   - uygun
   - var
   - yasa
+  - led

--- a/config/stemmer.yml
+++ b/config/stemmer.yml
@@ -237,3 +237,4 @@ selection_list_exceptions:
   - var
   - yasa
   - led
+  - gaz


### PR DESCRIPTION
ledli:
 * last consonant exception prevents `led` -> `let` (since it's not a
 native  turkish word it makes sense to ignore the harmony rule)
 * selection list exceptions prevents stem candidates other than `led`
 to be selected

kurutma:
 There is no specific exception list for the `noun_suffix_machine` which
 creates the `kurutm` and `kurut` candidates, so this term was put in
 `protected` words.